### PR TITLE
Remove outdated reaction forces section from Phase_Field_Fracture doc…

### DIFF
--- a/docs/source/api/Element/Phase_Field_Fracture/main.rst
+++ b/docs/source/api/Element/Phase_Field_Fracture/main.rst
@@ -37,15 +37,6 @@ $f(\bar{\alpha})$ Fatigue Degradation functions
    :show-inheritance:
 
 
-Reaction forces
----------------
-
-.. automodule:: phasefieldx.Element.reactions_forces_functions
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
 Solver
 ------
 

--- a/docs/source/api/Reactions/main.rst
+++ b/docs/source/api/Reactions/main.rst
@@ -1,0 +1,10 @@
+Reactions
+=========
+
+Reaction forces
+---------------
+
+.. automodule:: phasefieldx.Reactions.reaction_forces
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -16,4 +16,5 @@ Welcome to the API Reference chapter of our documentation! This section provides
    Materials/main
    Math/main
    PostProcessing/main
+   Reactions/main
    Solvers/main


### PR DESCRIPTION
…umentation and add Reactions documentation with corresponding module details.

This pull request reorganizes the documentation structure by moving the "Reaction forces" section from the `Element` module to a new `Reactions` module and updates the API reference index to reflect this change.

Documentation restructuring:

* [`docs/source/api/Element/Phase_Field_Fracture/main.rst`](diffhunk://#diff-0ebf01bb88bb1d0332c5a8a0ea97c3902032995921c12f899b2e862c26c3ba4bL40-L48): Removed the "Reaction forces" section from the `Element` module documentation.
* [`docs/source/api/Reactions/main.rst`](diffhunk://#diff-1a78c4ddddcb4d358cdb6218ade52a0f4089f276fe6c1b5e2d313a0d3576531dR1-R10): Created a new `Reactions` module documentation and added the "Reaction forces" section under it.

API reference update:

* [`docs/source/api/index.rst`](diffhunk://#diff-e759adbed3c551bf6129b16ddcff2f496852c6e1fe37fa0bb8c36af48da5dd19R19): Updated the API reference index to include the new `Reactions/main` entry.